### PR TITLE
Set oauth2 scopes at init

### DIFF
--- a/httpx_oauth/clients/facebook.py
+++ b/httpx_oauth/clients/facebook.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple, cast
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 import httpx
 

--- a/httpx_oauth/clients/facebook.py
+++ b/httpx_oauth/clients/facebook.py
@@ -16,14 +16,20 @@ class GetLongLivedAccessTokenError(Exception):
 
 
 class FacebookOAuth2(BaseOAuth2[Dict[str, Any]]):
-    def __init__(self, client_id: str, client_secret: str, name: str = "facebook"):
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        scopes: Optional[List[str]] = BASE_SCOPES,
+        name: str = "facebook",
+    ):
         super().__init__(
             client_id,
             client_secret,
             AUTHORIZE_ENDPOINT,
             ACCESS_TOKEN_ENDPOINT,
             name=name,
-            base_scopes=BASE_SCOPES,
+            base_scopes=scopes,
         )
 
     async def get_long_lived_access_token(self, token: str):

--- a/httpx_oauth/clients/github.py
+++ b/httpx_oauth/clients/github.py
@@ -19,14 +19,20 @@ class GitHubOAuth2AuthorizeParams(TypedDict, total=False):
 
 
 class GitHubOAuth2(BaseOAuth2[GitHubOAuth2AuthorizeParams]):
-    def __init__(self, client_id: str, client_secret: str, name: str = "github"):
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        scopes: Optional[List[str]] = BASE_SCOPES,
+        name: str = "github",
+    ):
         super().__init__(
             client_id,
             client_secret,
             AUTHORIZE_ENDPOINT,
             ACCESS_TOKEN_ENDPOINT,
             name=name,
-            base_scopes=BASE_SCOPES,
+            base_scopes=scopes,
         )
 
     async def get_id_email(self, token: str) -> Tuple[str, str]:

--- a/httpx_oauth/clients/github.py
+++ b/httpx_oauth/clients/github.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple, cast
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 import httpx
 from typing_extensions import TypedDict

--- a/httpx_oauth/clients/google.py
+++ b/httpx_oauth/clients/google.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple, List, Optional, cast
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 import httpx
 from typing_extensions import Literal, TypedDict

--- a/httpx_oauth/clients/google.py
+++ b/httpx_oauth/clients/google.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple, cast
+from typing import Any, Dict, Tuple, List, Optional, cast
 
 import httpx
 from typing_extensions import Literal, TypedDict
@@ -24,7 +24,13 @@ class GoogleOAuth2AuthorizeParams(TypedDict, total=False):
 
 
 class GoogleOAuth2(BaseOAuth2[GoogleOAuth2AuthorizeParams]):
-    def __init__(self, client_id: str, client_secret: str, name="google"):
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        scope: Optional[List[str]] = BASE_SCOPES,
+        name="google",
+    ):
         super().__init__(
             client_id,
             client_secret,
@@ -33,7 +39,7 @@ class GoogleOAuth2(BaseOAuth2[GoogleOAuth2AuthorizeParams]):
             ACCESS_TOKEN_ENDPOINT,
             REVOKE_TOKEN_ENDPOINT,
             name=name,
-            base_scopes=BASE_SCOPES,
+            base_scopes=scope,
         )
 
     async def get_id_email(self, token: str) -> Tuple[str, str]:

--- a/httpx_oauth/clients/linkedin.py
+++ b/httpx_oauth/clients/linkedin.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple, cast
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 import httpx
 

--- a/httpx_oauth/clients/linkedin.py
+++ b/httpx_oauth/clients/linkedin.py
@@ -13,7 +13,13 @@ EMAIL_ENDPOINT = "https://api.linkedin.com/v2/emailAddress"
 
 
 class LinkedInOAuth2(BaseOAuth2[Dict[str, Any]]):
-    def __init__(self, client_id: str, client_secret: str, name: str = "linkedin"):
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        scopes: Optional[List[str]] = BASE_SCOPES,
+        name: str = "linkedin",
+    ):
         super().__init__(
             client_id,
             client_secret,
@@ -21,7 +27,7 @@ class LinkedInOAuth2(BaseOAuth2[Dict[str, Any]]):
             ACCESS_TOKEN_ENDPOINT,
             ACCESS_TOKEN_ENDPOINT,
             name=name,
-            base_scopes=BASE_SCOPES,
+            base_scopes=scopes,
         )
 
     async def get_id_email(self, token: str) -> Tuple[str, str]:

--- a/httpx_oauth/clients/microsoft.py
+++ b/httpx_oauth/clients/microsoft.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple, cast
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 import httpx
 

--- a/httpx_oauth/clients/microsoft.py
+++ b/httpx_oauth/clients/microsoft.py
@@ -17,6 +17,7 @@ class MicrosoftGraphOAuth2(BaseOAuth2[Dict[str, Any]]):
         client_id: str,
         client_secret: str,
         tenant: str = "common",
+        scopes: Optional[List[str]] = BASE_SCOPES,
         name: str = "microsoft",
     ):
         access_token_endpoint = ACCESS_TOKEN_ENDPOINT.format(tenant=tenant)
@@ -27,7 +28,7 @@ class MicrosoftGraphOAuth2(BaseOAuth2[Dict[str, Any]]):
             access_token_endpoint,
             access_token_endpoint,
             name=name,
-            base_scopes=BASE_SCOPES,
+            base_scopes=scopes,
         )
 
     def get_authorization_url(

--- a/httpx_oauth/oauth2.py
+++ b/httpx_oauth/oauth2.py
@@ -102,8 +102,10 @@ class BaseOAuth2(Generic[T]):
         if state is not None:
             params["state"] = state
 
-        if scope is not None:
-            params["scope"] = " ".join(scope)
+        # Provide compatibility with current scope from the endpoint
+        _scope = scope or self.base_scopes
+        if _scope is not None:
+            params["scope"] = " ".join(_scope)
 
         if extras_params is not None:
             params = {**params, **extras_params}  # type: ignore


### PR DESCRIPTION
Scopes now can be defined at `BaseOAuth2` and `clients.*` init time, i.e.:
```python
            oauth_google_client = GoogleOAuth2(
                client_id=self.oauth_google_client,
                client_secret=self.oauth_google_secret,
                scopes=self.oauth_google_scopes, # i.e ["email"]
                name="google",
            )
```

If no scopes provided will use class default scopes (`BASE_SCOPES`).

Also `BaseOAuth2.get_authorization_url` method uses `BASE_SCOPES` if no `scope` is provided.

Fix #254 
Discussed at #253 