### PR TITLE
Add support for Okta

### DIFF
--- a/docs/oauth2.md
+++ b/docs/oauth2.md
@@ -182,3 +182,15 @@ client = LinkedInOAuth2("CLIENT_ID", "CLIENT_SECRET")
 
 * ✅ `refresh_token` (only for [selected partners](https://docs.microsoft.com/en-us/linkedin/shared/authentication/programmatic-refresh-tokens))
 * ❌ `revoke_token`
+
+
+### Okta
+
+```py
+from httpx_oauth.clients.okta import OktaOAuth2
+
+client = OktaOAuth2("CLIENT_ID", "CLIENT_SECRET", "OKTA_BASE_URL")
+```
+
+* ✅ `refresh_token`
+* ✅ `revoke_token`

--- a/httpx_oauth/clients/okta.py
+++ b/httpx_oauth/clients/okta.py
@@ -1,0 +1,46 @@
+from typing import Any, Dict, List, Optional, Tuple, cast
+
+import httpx
+
+from httpx_oauth.errors import GetIdEmailError
+from httpx_oauth.oauth2 import BaseOAuth2
+
+BASE_SCOPES = ["openid", "email"]
+
+
+class OktaOAuth2(BaseOAuth2[BaseOAuth2[Dict[str, Any]]]):
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        okta_base_url: str,
+        scopes: Optional[List[str]] = BASE_SCOPES,
+        name: str = "okta",
+    ):
+        super().__init__(
+            client_id,
+            client_secret,
+            f"https://{okta_base_url}/oauth2/v1/authorize",
+            f"https://{okta_base_url}/oauth2/v1/token",
+            f"https://{okta_base_url}/oauth2/v1/token",
+            f"https://{okta_base_url}/oauth2/v1/revoke",
+            name=name,
+            base_scopes=scopes,
+        )
+        self.profile = f"https://{okta_base_url}/oauth2/v1/userinfo"
+
+    async def get_id_email(self, token: str) -> Tuple[str, str]:
+        async with httpx.AsyncClient(
+            headers={**self.request_headers, "Authorization": f"Bearer {token}"}
+        ) as client:
+            response = await client.get(self.profile)
+
+            if response.status_code >= 400:
+                raise GetIdEmailError(response.json())
+
+            data = cast(Dict[str, Any], response.json())
+
+            user_id = data["sub"]
+            email = data["email"]
+
+            return str(user_id), email

--- a/tests/test_clients_okta.py
+++ b/tests/test_clients_okta.py
@@ -1,0 +1,55 @@
+import re
+
+import pytest
+import respx
+from httpx import Response
+
+from httpx_oauth.clients.okta import OktaOAuth2
+from httpx_oauth.errors import GetIdEmailError
+
+OKTA_BASE_URL = "test-okta-base-url.okta.com"
+
+client = OktaOAuth2("CLIENT_ID", "CLIENT_SECRET", OKTA_BASE_URL)
+
+
+def test_github_oauth2():
+    assert client.authorize_endpoint == f"https://{OKTA_BASE_URL}/oauth2/v1/authorize"
+    assert client.access_token_endpoint == f"https://{OKTA_BASE_URL}/oauth2/v1/token"
+    assert client.refresh_token_endpoint == f"https://{OKTA_BASE_URL}/oauth2/v1/token"
+    assert client.revoke_token_endpoint == f"https://{OKTA_BASE_URL}/oauth2/v1/revoke"
+    assert client.base_scopes == ["openid", "email"]
+    assert client.name == "okta"
+
+
+profile_response = {"sub": 42, "email": "arthur@camelot.bt"}
+profile_response_no_public_email = {"sub": 42, "email": None}
+
+
+class TestOktaGetIdEmail:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_success(self, get_respx_call_args):
+        request = respx.get(re.compile(f"^{client.profile}")).mock(
+            return_value=Response(200, json=profile_response)
+        )
+
+        user_id, user_email = await client.get_id_email("TOKEN")
+        _, headers, _ = await get_respx_call_args(request)
+
+        assert headers["Authorization"] == "Bearer TOKEN"
+        assert headers["Accept"] == "application/json"
+        assert user_id == "42"
+        assert user_email == "arthur@camelot.bt"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_error(self):
+        respx.get(re.compile(f"^{client.profile}")).mock(
+            return_value=Response(400, json={"error": "message"})
+        )
+
+        with pytest.raises(GetIdEmailError) as excinfo:
+            await client.get_id_email("TOKEN")
+
+        assert type(excinfo.value.args[0]) == dict
+        assert excinfo.value.args[0] == {"error": "message"}

--- a/tests/test_clients_okta.py
+++ b/tests/test_clients_okta.py
@@ -12,7 +12,7 @@ OKTA_BASE_URL = "test-okta-base-url.okta.com"
 client = OktaOAuth2("CLIENT_ID", "CLIENT_SECRET", OKTA_BASE_URL)
 
 
-def test_github_oauth2():
+def test_okta_oauth2():
     assert client.authorize_endpoint == f"https://{OKTA_BASE_URL}/oauth2/v1/authorize"
     assert client.access_token_endpoint == f"https://{OKTA_BASE_URL}/oauth2/v1/token"
     assert client.refresh_token_endpoint == f"https://{OKTA_BASE_URL}/oauth2/v1/token"


### PR DESCRIPTION
This PR serves to add support for Okta, an identity and access management company used by many companies.

Link to Okta endpoints: https://developer.okta.com/docs/reference/api/oidc/

To set up Okta for usage follow the following steps.
1. Create an Okta account
2. Click "Applications", "Create App Integration", select "OIDC - OpenID Connect", "Web Application"
3. Set the callback url to match the endpoint in your app
4. Save
5. You will then find your client_id, client_secret, and okta_base_url