### PR TITLE
Generate setup.py

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,4 +47,4 @@ jobs:
         FLIT_USERNAME: ${{ secrets.FLIT_USERNAME }}
         FLIT_PASSWORD: ${{ secrets.FLIT_PASSWORD }}
       run: |
-        flit publish
+        flit publish --setup-py


### PR DESCRIPTION
FreeBSD, among other operating systems, uses setup.py when building Python packages. It would make it much easier for maintainers if this file existed.