### PR TITLE
Add OAuth 2.0 client for NAVER

### DIFF
--- a/docs/oauth2.md
+++ b/docs/oauth2.md
@@ -211,6 +211,17 @@ client = LinkedInOAuth2("CLIENT_ID", "CLIENT_SECRET")
 * ✅ `refresh_token` (only for [selected partners](https://docs.microsoft.com/en-us/linkedin/shared/authentication/programmatic-refresh-tokens))
 * ❌ `revoke_token`
 
+### NAVER
+
+```py
+from httpx_oauth.clients.naver import NaverOAuth2
+
+client = NaverOAuth2("CLIENT_ID", "CLIENT_SECRET")
+```
+
+* ✅ `refresh_token`
+* ✅ `revoke_token`
+
 ### Okta
 
 Based on the [OpenID client](#openid). You need to provide the domain of your Okta domain for automatically discovering the required endpoints.

--- a/httpx_oauth/clients/naver.py
+++ b/httpx_oauth/clients/naver.py
@@ -1,0 +1,82 @@
+from typing import Any, Dict, List, Optional, Tuple, cast
+
+import httpx_oauth.oauth2 as oauth
+from httpx_oauth.errors import GetIdEmailError
+from httpx_oauth.oauth2 import BaseOAuth2
+
+
+AUTHORIZE_ENDPOINT = "https://nid.naver.com/oauth2.0/authorize"
+ACCESS_TOKEN_ENDPOINT = "https://nid.naver.com/oauth2.0/token"
+REFRESH_TOKEN_ENDPOINT = ACCESS_TOKEN_ENDPOINT
+REVOKE_TOKEN_ENDPOINT = ACCESS_TOKEN_ENDPOINT
+PROFILE_ENDPOINT = "https://openapi.naver.com/v1/nid/me"
+BASE_SCOPES = []
+
+LOGO_SVG = """
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" version="1.1" xml:space="preserve" width="40" height="40" viewBox="0 0 40 40">
+  <g xmlns="http://www.w3.org/2000/svg" transform="translate(36,0)">
+    <path d="m 0,0 h -32 c -2.2,0 -4,1.8 -4,4 v 32 c 0,2.2 1.8,4 4,4 H 0 c 2.2,0 4,-1.8 4,-4 V 4 C 4,1.8 2.2,0 0,0" style="fill:#03c75a;fill-opacity:1;fill-rule:nonzero;stroke:none"/>
+  </g>
+  <g xmlns="http://www.w3.org/2000/svg" transform="translate(17.332,18.662) scale(-1,1)">
+    <path d="m 0,0 -5.683,8.135 h -4.711 V -7.064 h 4.935 V 1.071 L 0.224,-7.064 H 4.935 V 8.135 H 0 Z" style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"/>
+  </g>
+</svg>
+"""
+
+class NaverOAuth2(BaseOAuth2[Dict[str, Any]]):
+    display_name = "Naver"
+    logo_svg = LOGO_SVG
+
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        scopes: Optional[List[str]] = BASE_SCOPES,
+        name: str = "naver",
+    ):
+        super().__init__(
+            client_id,
+            client_secret,
+            AUTHORIZE_ENDPOINT,
+            ACCESS_TOKEN_ENDPOINT,
+            refresh_token_endpoint=REFRESH_TOKEN_ENDPOINT,
+            revoke_token_endpoint=REVOKE_TOKEN_ENDPOINT,
+            name=name,
+            base_scopes=scopes,
+        )
+
+    async def revoke_token(self, token: str, token_type_hint: str = None) -> None:
+        async with self.get_httpx_client() as client:
+            data = {
+                "grant_type": "delete",
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+                "access_token": token,
+                "service_provider": "NAVER"
+            }
+
+            if token_type_hint is not None:
+                data["token_type_hint"] = token_type_hint
+
+            response = await client.post(
+                self.revoke_token_endpoint, data=data, headers=self.request_headers
+            )
+
+            if response.status_code >= 400:
+                raise oauth.RevokeTokenError()
+
+
+    async def get_id_email(self, token: str) -> Tuple[str, Optional[str]]:
+        async with self.get_httpx_client() as client:
+            response = await client.post(
+                PROFILE_ENDPOINT,
+                headers={**self.request_headers,
+                         "Authorization": f"Bearer {token}"},
+            )
+
+            if response.status_code >= 400:
+                raise GetIdEmailError(response.json())
+
+            account_info = cast(Dict[str, Any], response.json())
+            account_info = account_info.get('response')
+            return account_info.get('id'), account_info.get('email')

--- a/tests/test_clients_naver.py
+++ b/tests/test_clients_naver.py
@@ -1,0 +1,79 @@
+import re
+
+import pytest
+import respx
+from httpx import Response
+
+from httpx_oauth.clients.naver import NaverOAuth2, PROFILE_ENDPOINT
+from httpx_oauth.errors import GetIdEmailError
+
+client = NaverOAuth2("CLIENT_ID", "CLIENT_SECRET")
+
+
+def test_naver_oauth2():
+    assert client.authorize_endpoint == "https://nid.naver.com/oauth2.0/authorize"
+    assert client.access_token_endpoint == "https://nid.naver.com/oauth2.0/token"
+    assert client.refresh_token_endpoint == "https://nid.naver.com/oauth2.0/token"
+    assert client.revoke_token_endpoint == "https://nid.naver.com/oauth2.0/token"
+    assert client.base_scopes == []
+    assert client.name == "naver"
+
+
+profile_response = {
+    "resultcode": "00",
+    "message": "success",
+    "response": {
+        "id": "424242424242424242424242",
+        "email": "example@naver.com",
+    }
+}
+
+profile_no_email_response = {
+    "resultcode": "00",
+    "message": "success",
+    "response": {
+        "id": "424242424242424242424242",
+    }
+}
+
+
+class TestDiscordGetIdEmail:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_success(self, get_respx_call_args):
+        request = respx.post(re.compile(f"^{PROFILE_ENDPOINT}")).mock(
+            return_value=Response(200, json=profile_response)
+        )
+
+        user_id, user_email = await client.get_id_email("TOKEN")
+        _, headers, _ = await get_respx_call_args(request)
+
+        assert headers["Authorization"] == "Bearer TOKEN"
+        assert headers["Accept"] == "application/json"
+        assert user_id == "424242424242424242424242"
+        assert user_email == "example@naver.com"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_error(self):
+        respx.post(re.compile(f"^{PROFILE_ENDPOINT}")).mock(
+            return_value=Response(400, json={"error": "message"})
+        )
+
+        with pytest.raises(GetIdEmailError) as excinfo:
+            await client.get_id_email("TOKEN")
+
+        assert type(excinfo.value.args[0]) == dict
+        assert excinfo.value.args[0] == {"error": "message"}
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_no_email(self):
+        respx.post(re.compile(f"^{PROFILE_ENDPOINT}$")).mock(
+            return_value=Response(200, json=profile_no_email_response)
+        )
+
+        user_id, user_email = await client.get_id_email("TOKEN")
+
+        assert user_id == "424242424242424242424242"
+        assert user_email is None


### PR DESCRIPTION
created new client for NAVER.

- [x] Add Client
- [x] Update documentation
- [x] Add PyTest

for information, [NAVER](https://www.navercorp.com/en/service/featured) is a one of famous web service for search in South Korea.