### PR TITLE
Add OAuth 2.0 client for Twitch

### DIFF
--- a/docs/fastapi.md
+++ b/docs/fastapi.md
@@ -15,6 +15,7 @@ Dependency callable to handle the authorization callback. It reads the query par
     You should either set `route_name`, which will automatically reverse the URL, or `redirect_url`, which is an arbitrary URL you set.
 
 ```py
+from fastapi import Depends, FastAPI
 from httpx_oauth.integrations.fastapi import OAuth2AuthorizeCallback
 from httpx_oauth.oauth2 import OAuth2
 

--- a/docs/oauth2.md
+++ b/docs/oauth2.md
@@ -259,7 +259,21 @@ client = RedditOAuth2("CLIENT_ID", "CLIENT_SECRET")
 
 !!! warning "Warning about `get_id_email`"
     Reddit API never return email addresses. Thus, e-mail will *always* be `None`.
-    ```
+
+
+### Twitch
+
+```py
+from httpx_oauth.clients.twitch import TwitchOAuth2
+
+client = TwitchOAuth2("CLIENT_ID", "CLIENT_SECRET")
+```
+
+* ✅ `refresh_token`
+* ✅ `revoke_token`
+
+!!! tip
+        To include the user’s verified email address in the response, you must use a user access token that includes the `user:read:email` scope (see [Twitch API documentation](https://dev.twitch.tv/docs/api/reference#get-users)), otherwise it will be `None`.
 
 ## Customize HTTPX client
 

--- a/docs/oauth2.md
+++ b/docs/oauth2.md
@@ -260,7 +260,6 @@ client = RedditOAuth2("CLIENT_ID", "CLIENT_SECRET")
 !!! warning "Warning about `get_id_email`"
     Reddit API never return email addresses. Thus, e-mail will *always* be `None`.
 
-
 ### Twitch
 
 ```py

--- a/httpx_oauth/clients/twitch.py
+++ b/httpx_oauth/clients/twitch.py
@@ -1,0 +1,93 @@
+from typing import Any, Dict, List, Optional, Tuple, cast
+
+from httpx_oauth.errors import GetIdEmailError
+from httpx_oauth.oauth2 import BaseOAuth2
+
+AUTHORIZE_ENDPOINT = "https://id.twitch.tv/oauth2/authorize"
+ACCESS_TOKEN_ENDPOINT = "https://id.twitch.tv/oauth2/token"
+REVOKE_TOKEN_ENDPOINT = "https://id.twitch.tv/oauth2/revoke"
+BASE_SCOPES = [
+    "user:read:email",
+    "user:read:follows",
+    "user:read:subscriptions",
+    "user:manage:whispers",
+]
+
+"""
+If an ID or login name is not specified, the request to the user endpoint returns 
+information about the user specified in the included access token.
+
+https://dev.twitch.tv/docs/api/reference#get-users
+"""
+PROFILE_ENDPOINT = "https://api.twitch.tv/helix/users"
+
+LOGO_SVG = """
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 2400 2800" style="enable-background:new 0 0 2400 2800;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+	.st1{fill:#9146FF;}
+</style>
+<g>
+	<polygon class="st0" points="2200,1300 1800,1700 1400,1700 1050,2050 1050,1700 600,1700 600,200 2200,200 	"/>
+	<g>
+		<g id="Layer_1-2">
+			<path class="st1" d="M500,0L0,500v1800h600v500l500-500h400l900-900V0H500z M2200,1300l-400,400h-400l-350,350v-350H600V200h1600
+				V1300z"/>
+			<rect x="1700" y="550" class="st1" width="200" height="600"/>
+			<rect x="1150" y="550" class="st1" width="200" height="600"/>
+		</g>
+	</g>
+</g>
+</svg>
+"""
+
+
+class TwitchOAuth2(BaseOAuth2[Dict[str, Any]]):
+    display_name = "Twitch"
+    logo_svg = LOGO_SVG
+
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        scope: Optional[List[str]] = BASE_SCOPES,
+        name="twitch",
+    ):
+        super().__init__(
+            client_id,
+            client_secret,
+            AUTHORIZE_ENDPOINT,
+            ACCESS_TOKEN_ENDPOINT,
+            ACCESS_TOKEN_ENDPOINT,
+            REVOKE_TOKEN_ENDPOINT,
+            name=name,
+            base_scopes=scope,
+        )
+
+    async def get_id_email(self, token: str) -> Tuple[str, Optional[str]]:
+        async with self.get_httpx_client() as client:
+            response = await client.get(
+                PROFILE_ENDPOINT,
+                headers={
+                    "Client-Id": self.client_id,
+                    "Authorization": f"Bearer {token}",
+                },
+            )
+
+            if response.status_code >= 400:
+                raise GetIdEmailError(response.json())
+
+            response_body = cast(Dict[str, Any], response.json())
+
+            user_id = response_body["data"][0]["id"]
+
+            """
+            To include the user's verified email address in the response, you must use 
+            a user access token that includes the 'user:read:email' scope.
+
+            https://dev.twitch.tv/docs/api/reference#get-users
+            """
+            user_email = response_body["data"][0].get("email")
+
+            return user_id, user_email

--- a/httpx_oauth/clients/twitch.py
+++ b/httpx_oauth/clients/twitch.py
@@ -22,23 +22,11 @@ https://dev.twitch.tv/docs/api/reference#get-users
 PROFILE_ENDPOINT = "https://api.twitch.tv/helix/users"
 
 LOGO_SVG = """
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 2400 2800" style="enable-background:new 0 0 2400 2800;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#FFFFFF;}
-	.st1{fill:#9146FF;}
-</style>
-<g>
-	<polygon class="st0" points="2200,1300 1800,1700 1400,1700 1050,2050 1050,1700 600,1700 600,200 2200,200 	"/>
-	<g>
-		<g id="Layer_1-2">
-			<path class="st1" d="M500,0L0,500v1800h600v500l500-500h400l900-900V0H500z M2200,1300l-400,400h-400l-350,350v-350H600V200h1600
-				V1300z"/>
-			<rect x="1700" y="550" class="st1" width="200" height="600"/>
-			<rect x="1150" y="550" class="st1" width="200" height="600"/>
-		</g>
-	</g>
-</g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="256px" height="268px" viewBox="0 0 256 268" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" preserveAspectRatio="xMidYMid">
+    <g>
+        <path d="M17.4579119,0 L0,46.5559188 L0,232.757287 L63.9826001,232.757287 L63.9826001,267.690956 L98.9144853,267.690956 L133.811571,232.757287 L186.171922,232.757287 L256,162.954193 L256,0 L17.4579119,0 Z M40.7166868,23.2632364 L232.73141,23.2632364 L232.73141,151.29179 L191.992415,192.033461 L128,192.033461 L93.11273,226.918947 L93.11273,192.033461 L40.7166868,192.033461 L40.7166868,23.2632364 Z M104.724985,139.668381 L127.999822,139.668381 L127.999822,69.843872 L104.724985,69.843872 L104.724985,139.668381 Z M168.721862,139.668381 L191.992237,139.668381 L191.992237,69.843872 L168.721862,69.843872 L168.721862,139.668381 Z" fill="#5A3E85"></path>
+    </g>
 </svg>
 """
 

--- a/tests/test_clients_twitch.py
+++ b/tests/test_clients_twitch.py
@@ -1,0 +1,71 @@
+import re
+
+import pytest
+import respx
+from httpx import Response
+
+from httpx_oauth.clients.twitch import PROFILE_ENDPOINT, TwitchOAuth2
+from httpx_oauth.errors import GetIdEmailError
+
+client = TwitchOAuth2("CLIENT_ID", "CLIENT_SECRET")
+
+
+def test_twitch_oauth2():
+    assert client.authorize_endpoint == "https://id.twitch.tv/oauth2/authorize"
+    assert client.access_token_endpoint == "https://id.twitch.tv/oauth2/token"
+    assert client.refresh_token_endpoint == "https://id.twitch.tv/oauth2/token"
+    assert client.revoke_token_endpoint == "https://id.twitch.tv/oauth2/revoke"
+    assert client.base_scopes == [
+        "user:read:email",
+        "user:read:follows",
+        "user:read:subscriptions",
+        "user:manage:whispers",
+    ]
+    assert client.name == "twitch"
+
+
+class TestTwitchGetIdEmail:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_success_with_email(self, get_respx_call_args):
+        profile_response = {"data": [{"id": "12345", "email": "test.user@domain.com"}]}
+        request = respx.get(re.compile(f"^{PROFILE_ENDPOINT}")).mock(
+            return_value=Response(200, json=profile_response)
+        )
+
+        user_id, user_email = await client.get_id_email("TOKEN")
+        url, headers, content = await get_respx_call_args(request)
+
+        assert headers["Authorization"] == "Bearer TOKEN"
+        assert headers["Client-Id"] == client.client_id
+        assert user_id == "12345"
+        assert user_email == "test.user@domain.com"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_success_with_no_email(self, get_respx_call_args):
+        profile_response = {"data": [{"id": "12345"}]}
+        request = respx.get(re.compile(f"^{PROFILE_ENDPOINT}")).mock(
+            return_value=Response(200, json=profile_response)
+        )
+
+        user_id, user_email = await client.get_id_email("TOKEN")
+        url, headers, content = await get_respx_call_args(request)
+
+        assert headers["Authorization"] == "Bearer TOKEN"
+        assert headers["Client-Id"] == client.client_id
+        assert user_id == "12345"
+        assert user_email is None
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_error(self):
+        respx.get(re.compile(f"^{PROFILE_ENDPOINT}")).mock(
+            return_value=Response(400, json={"error": "message"})
+        )
+
+        with pytest.raises(GetIdEmailError) as excinfo:
+            await client.get_id_email("TOKEN")
+
+        assert type(excinfo.value.args[0]) == dict
+        assert excinfo.value.args[0] == {"error": "message"}


### PR DESCRIPTION
Added OAuth 2.0 client for Twitch along with tests and updated the examples in the `Provided clients` section of the documentation.