### PR TITLE
docs: remove stray code block in "Reddit" section in oauth2.md

### DIFF
--- a/docs/oauth2.md
+++ b/docs/oauth2.md
@@ -259,7 +259,6 @@ client = RedditOAuth2("CLIENT_ID", "CLIENT_SECRET")
 
 !!! warning "Warning about `get_id_email`"
     Reddit API never return email addresses. Thus, e-mail will *always* be `None`.
-    ```
 
 ## Customize HTTPX client
 


### PR DESCRIPTION
Issue originally introduced in d659f36e9d5e0d3072adbda6d13006e8798bd698.