### PR TITLE
Fix use Github primary email instead of first

### DIFF
--- a/httpx_oauth/clients/github.py
+++ b/httpx_oauth/clients/github.py
@@ -69,6 +69,7 @@ class GitHubOAuth2(BaseOAuth2[GitHubOAuth2AuthorizeParams]):
 
                 emails = cast(List[Dict[str, Any]], response.json())
 
-                email = emails[0]["email"]
+                # Use the primary email if it exists, otherwise the first
+                email = next((e["email"] for e in emails if e.get("primary")), emails[0]["email"])
 
             return str(id), email


### PR DESCRIPTION
When no public email address is defined in the user's profile this PR uses the user's primary address instead of the first one found. If no primary is defined it (I don't think this could ever happen) it would fall back to the previous behaviour of using the first one.

Fixes #317