### PR TITLE
update setup-uv action to immutable release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Just
         uses: extractions/setup-just@v3
       - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: ${{ matrix.python_version }}
       - name: Install the project
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Just
         uses: extractions/setup-just@v3
       - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: "3.10"
       - name: Install the project

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Just
         uses: extractions/setup-just@v3
       - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: "3.10"
       - name: Install the project


### PR DESCRIPTION
This PR switches `setup-uv` action from using floating major tags to use a specific version tag (v8.1.0) to ensure the CI remains stable and compatible with future releases. Thanks!